### PR TITLE
History-command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "java.configuration.updateBuildConfiguration": "automatic",
     "java.format.settings.url": "eclipse-formatter.xml",
-    "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m"
+    "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m",
+    "remote.SSH.useLocalServer": false
 }

--- a/honeypot-core/pom.xml
+++ b/honeypot-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.reprogle</groupId>
         <artifactId>honeypot-parent</artifactId>
-        <version>2.3.1</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>honeypot-api</artifactId>
-            <version>2.3.1</version>
+            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>dev.dejvokep</groupId>

--- a/honeypot-core/pom.xml
+++ b/honeypot-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.reprogle</groupId>
         <artifactId>honeypot-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>honeypot-api</artifactId>
-            <version>2.4.0</version>
+            <version>2.5.0</version>
         </dependency>
         <dependency>
             <groupId>dev.dejvokep</groupId>

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/Honeypot.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/Honeypot.java
@@ -3,6 +3,7 @@ package org.reprogle.honeypot;
 import java.io.File;
 
 import org.bstats.bukkit.Metrics;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.RegisteredServiceProvider;
@@ -122,6 +123,10 @@ public final class Honeypot extends JavaPlugin {
             "|__|__|___|_|_|___|_  |  _|___|_|      version " + ChatColor.RED + this.getDescription().getVersion() + "\n" + ChatColor.GOLD + 
             "                  |___|_|");
 
+        if(!versionCheck()) {
+            getServer().getLogger().warning("Honeypot is not guaranteed to support this version of Spigot. We won't prevent you from using it, but some newer blocks (If any) may exhibit unusual behavior!");
+        }
+
         // Check for any updates
         new HoneypotUpdateChecker(this, "https://raw.githubusercontent.com/TerrrorByte/Honeypot/master/version.txt")
                 .getVersion(latest -> {
@@ -175,6 +180,20 @@ public final class Honeypot extends JavaPlugin {
         RegisteredServiceProvider<Permission> rsp = getServer().getServicesManager().getRegistration(Permission.class);
         perms = rsp.getProvider();
         return perms != null;
+    }
+
+    /**
+     * Check the version of Spigot we're running on. Current supported version is 1.17 - 1.19.2
+     * @return True if the version is supported, false if not
+     */
+    public static boolean versionCheck() {
+        String[] split = Bukkit.getBukkitVersion().split("-")[0].split("\\.");
+        int majorVer = Integer.parseInt(split[0]);
+        int minorVer = Integer.parseInt(split[1]);
+        int revisionVer = split.length > 2 ? Integer.parseInt(split[2]) : 0;
+
+        // Return true if between 1.17 & 1.19.2
+        return (majorVer == 1 && minorVer >= 17) && (majorVer == 1 && minorVer <= 19 && revisionVer <= 2);
     }
 
     /**

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/Honeypot.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/Honeypot.java
@@ -19,7 +19,9 @@ import org.reprogle.honeypot.storagemanager.HoneypotPlayerHistoryManager;
 import org.reprogle.honeypot.storagemanager.HoneypotPlayerManager;
 import org.reprogle.honeypot.utils.GhostHoneypotFixer;
 import org.reprogle.honeypot.utils.GriefPreventionUtil;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 import org.reprogle.honeypot.utils.HoneypotLogger;
+import org.reprogle.honeypot.utils.HoneypotUpdateChecker;
 import org.reprogle.honeypot.utils.WorldGuardUtil;
 
 import net.milkbowl.vault.permission.Permission;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandFeedback.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandFeedback.java
@@ -3,7 +3,7 @@ package org.reprogle.honeypot.commands;
 import java.util.Objects;
 
 import org.bukkit.ChatColor;
-import org.reprogle.honeypot.HoneypotConfigManager;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 
 import dev.dejvokep.boostedyaml.YamlDocument;
 

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandFeedback.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandFeedback.java
@@ -37,7 +37,8 @@ public class CommandFeedback {
                 "  " + ChatColor.WHITE + "/honeypot " + ChatColor.GRAY + "remove (all | near) (optional)\n" +
                 "  " + ChatColor.WHITE + "/honeypot " + ChatColor.GRAY + "reload\n" +
                 "  " + ChatColor.WHITE + "/honeypot " + ChatColor.GRAY + "locate\n" + 
-                "  " + ChatColor.WHITE + "/honeypot " + ChatColor.GRAY + "gui\n \n" + 
+                "  " + ChatColor.WHITE + "/honeypot " + ChatColor.GRAY + "gui\n" + 
+                "  " + ChatColor.WHITE + "/honeypot " + ChatColor.GRAY + "history [query | delete | purge] \n \n" +
                 ChatColor.WHITE + "-----------------------");
             }
 

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandFeedback.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandFeedback.java
@@ -50,11 +50,11 @@ public class CommandFeedback {
             case "alreadyexists" -> feedbackMessage = (chatPrefix + " " + ChatColor.translateAlternateColorCodes('&', languageFile.getString("already-exists")));
 
             case "success" -> {
-                if (success[0].equals(true)) {
+                if (success.length > 0 && success[0].equals(true)) {
                     feedbackMessage = (chatPrefix + " " + ChatColor.translateAlternateColorCodes('&', languageFile.getString("success.created")));
 
                 }
-                else if (success[0].equals(false)) {
+                else if (success.length > 0 && success[0].equals(false)) {
                     feedbackMessage = (chatPrefix + " " + ChatColor.translateAlternateColorCodes('&', languageFile.getString("success.removed")));
 
                 }
@@ -97,6 +97,14 @@ public class CommandFeedback {
             case "staffbroke" -> feedbackMessage = (chatPrefix + " " + ChatColor.translateAlternateColorCodes('&', languageFile.getString("staff-broke")));
 
             case "exemptnobreak" -> feedbackMessage = (chatPrefix + " " + ChatColor.translateAlternateColorCodes('&', languageFile.getString("exempt-no-break")));
+
+            case "searching" -> feedbackMessage = (chatPrefix + " " + ChatColor.translateAlternateColorCodes('&', languageFile.getString("searching")));
+
+            case "truncating" -> feedbackMessage = (chatPrefix + " " + ChatColor.translateAlternateColorCodes('&', languageFile.getString("truncating")));
+
+            case "notonline" -> feedbackMessage = (chatPrefix + " " + ChatColor.translateAlternateColorCodes('&', languageFile.getString("not-online")));
+
+            case "nohistory" -> feedbackMessage = (chatPrefix + " " + ChatColor.translateAlternateColorCodes('&', languageFile.getString("no-history")));
 
             default -> feedbackMessage = (chatPrefix + " " + ChatColor.DARK_RED + ChatColor.translateAlternateColorCodes('&', languageFile.getString("unknown-error")));
         }

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandManager.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandManager.java
@@ -15,6 +15,7 @@ import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.commands.subcommands.HoneypotCreate;
 import org.reprogle.honeypot.commands.subcommands.HoneypotGUI;
 import org.reprogle.honeypot.commands.subcommands.HoneypotHelp;
+import org.reprogle.honeypot.commands.subcommands.HoneypotHistory;
 import org.reprogle.honeypot.commands.subcommands.HoneypotInfo;
 import org.reprogle.honeypot.commands.subcommands.HoneypotLocate;
 import org.reprogle.honeypot.commands.subcommands.HoneypotReload;
@@ -44,6 +45,7 @@ public class CommandManager implements TabExecutor {
         subcommands.add(new HoneypotHelp());
         subcommands.add(new HoneypotUpgrade());
         subcommands.add(new HoneypotInfo());
+        subcommands.add(new HoneypotHistory());
 
         for (int i = 0; i < getSubcommands().size(); i++) {
             subcommandsNameOnly.add(getSubcommands().get(i).getName());

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandManager.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandManager.java
@@ -74,8 +74,6 @@ public class CommandManager implements TabExecutor {
     String label, @NotNull
     String[] args) {
 
-        if(!label.equalsIgnoreCase("honeypot")) return false;
-
         // Check if the command sender is a player
         if (sender instanceof Player p) {
 

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandManager.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandManager.java
@@ -1,8 +1,10 @@
 package org.reprogle.honeypot.commands;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
@@ -137,10 +139,18 @@ public class CommandManager implements TabExecutor {
                 }
             }
             else {
-                // If the sender is not a player (Probably the console) and did not use the reload command, send this
-                // message
-                Honeypot.getPlugin().getServer().getConsoleSender()
-                        .sendMessage(ChatColor.DARK_RED + "You must run this command as an in-game player!");
+                ConsoleCommandSender console = Honeypot.getPlugin().getServer().getConsoleSender();
+                console.sendMessage(ChatColor.GOLD + "\n" 
+                    + " _____                         _\n"
+                    + "|  |  |___ ___ ___ _ _ ___ ___| |_\n" 
+                    + "|     | . |   | -_| | | . | . |  _|    by" + ChatColor.RED + " TerrorByte\n" + ChatColor.GOLD 
+                    + "|__|__|___|_|_|___|_  |  _|___|_|      version " + ChatColor.RED + Honeypot.getPlugin().getDescription().getVersion() + "\n" + ChatColor.GOLD
+                    + "                  |___|_|"
+                );
+                console.sendMessage(CommandFeedback.getChatPrefix() + "Honeypot running on Spigot version " + Bukkit.getVersion());
+                if (!Honeypot.versionCheck()) {
+                    console.sendMessage(CommandFeedback.getChatPrefix() + "This version of Honeypot is not guaranteed to work on this version of Spigot. Some newer blocks (If any) may exhibit unusual behavior!");
+                }
             }
         }
 

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandManager.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandManager.java
@@ -13,6 +13,7 @@ import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.commands.subcommands.HoneypotCreate;
 import org.reprogle.honeypot.commands.subcommands.HoneypotGUI;
 import org.reprogle.honeypot.commands.subcommands.HoneypotHelp;
+import org.reprogle.honeypot.commands.subcommands.HoneypotInfo;
 import org.reprogle.honeypot.commands.subcommands.HoneypotLocate;
 import org.reprogle.honeypot.commands.subcommands.HoneypotReload;
 import org.reprogle.honeypot.commands.subcommands.HoneypotRemove;
@@ -40,6 +41,7 @@ public class CommandManager implements TabExecutor {
         subcommands.add(new HoneypotGUI());
         subcommands.add(new HoneypotHelp());
         subcommands.add(new HoneypotUpgrade());
+        subcommands.add(new HoneypotInfo());
 
         for (int i = 0; i < getSubcommands().size(); i++) {
             subcommandsNameOnly.add(getSubcommands().get(i).getName());

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandManager.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandManager.java
@@ -140,16 +140,16 @@ public class CommandManager implements TabExecutor {
             }
             else {
                 ConsoleCommandSender console = Honeypot.getPlugin().getServer().getConsoleSender();
-                console.sendMessage(ChatColor.GOLD + "\n" 
+                console.sendMessage(ChatColor.GOLD + "\n"
                     + " _____                         _\n"
                     + "|  |  |___ ___ ___ _ _ ___ ___| |_\n" 
                     + "|     | . |   | -_| | | . | . |  _|    by" + ChatColor.RED + " TerrorByte\n" + ChatColor.GOLD 
                     + "|__|__|___|_|_|___|_  |  _|___|_|      version " + ChatColor.RED + Honeypot.getPlugin().getDescription().getVersion() + "\n" + ChatColor.GOLD
                     + "                  |___|_|"
                 );
-                console.sendMessage(CommandFeedback.getChatPrefix() + "Honeypot running on Spigot version " + Bukkit.getVersion());
+                console.sendMessage(CommandFeedback.getChatPrefix() + " Honeypot running on Spigot version " + Bukkit.getVersion());
                 if (!Honeypot.versionCheck()) {
-                    console.sendMessage(CommandFeedback.getChatPrefix() + "This version of Honeypot is not guaranteed to work on this version of Spigot. Some newer blocks (If any) may exhibit unusual behavior!");
+                    console.sendMessage(CommandFeedback.getChatPrefix() + " This version of Honeypot is not guaranteed to work on this version of Spigot. Some newer blocks (If any) may exhibit unusual behavior!");
                 }
             }
         }

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandManager.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/CommandManager.java
@@ -11,7 +11,6 @@ import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.reprogle.honeypot.Honeypot;
-import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.commands.subcommands.HoneypotCreate;
 import org.reprogle.honeypot.commands.subcommands.HoneypotGUI;
 import org.reprogle.honeypot.commands.subcommands.HoneypotHelp;
@@ -21,6 +20,7 @@ import org.reprogle.honeypot.commands.subcommands.HoneypotLocate;
 import org.reprogle.honeypot.commands.subcommands.HoneypotReload;
 import org.reprogle.honeypot.commands.subcommands.HoneypotRemove;
 import org.reprogle.honeypot.commands.subcommands.HoneypotUpgrade;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotCreate.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotCreate.java
@@ -4,12 +4,12 @@ import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.reprogle.honeypot.Honeypot;
-import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.api.events.HoneypotCreateEvent;
 import org.reprogle.honeypot.api.events.HoneypotPreCreateEvent;
 import org.reprogle.honeypot.commands.CommandFeedback;
 import org.reprogle.honeypot.commands.HoneypotSubCommand;
 import org.reprogle.honeypot.utils.GriefPreventionUtil;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 import org.reprogle.honeypot.utils.WorldGuardUtil;
 
 import java.util.ArrayList;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotCreate.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotCreate.java
@@ -92,7 +92,7 @@ public class HoneypotCreate implements HoneypotSubCommand {
         }
 
         // If the block already exists in the DB
-        if (Boolean.TRUE.equals(Honeypot.getHBM().isHoneypotBlock(block))) {
+        if (Boolean.TRUE.equals(Honeypot.getBlockManager().isHoneypotBlock(block))) {
             p.sendMessage(CommandFeedback.sendCommandFeedback("alreadyexists"));
 
             // If the block doesn't exist
@@ -112,14 +112,14 @@ public class HoneypotCreate implements HoneypotSubCommand {
 
                 if (args[1].equalsIgnoreCase("custom")) {
                     if (!args[2].isEmpty() && HoneypotConfigManager.getHoneypotsConfig().contains(args[2])) {
-                        Honeypot.getHBM().createBlock(block, args[2]);
+                        Honeypot.getBlockManager().createBlock(block, args[2]);
                         p.sendMessage(CommandFeedback.sendCommandFeedback("success", true));
                     } else {
                         p.sendMessage(CommandFeedback.sendCommandFeedback("noexist"));
                     }
                 }
                 else {
-                    Honeypot.getHBM().createBlock(block, args[1]);
+                    Honeypot.getBlockManager().createBlock(block, args[1]);
                     p.sendMessage(CommandFeedback.sendCommandFeedback("success", true));
                 }
 

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotGUI.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotGUI.java
@@ -18,7 +18,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.reprogle.honeypot.Honeypot;
-import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.api.events.HoneypotPreCreateEvent;
 import org.reprogle.honeypot.commands.CommandFeedback;
 import org.reprogle.honeypot.commands.HoneypotSubCommand;
@@ -27,6 +26,7 @@ import org.reprogle.honeypot.gui.button.GUIButton;
 import org.reprogle.honeypot.gui.item.GUIItemBuilder;
 import org.reprogle.honeypot.storagemanager.HoneypotBlockObject;
 import org.reprogle.honeypot.utils.GriefPreventionUtil;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 import org.reprogle.honeypot.utils.WorldGuardUtil;
 
 import net.md_5.bungee.api.ChatColor;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotGUI.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotGUI.java
@@ -88,7 +88,7 @@ public class HoneypotGUI implements HoneypotSubCommand {
 
 		GUIMenu allBlocksGUI = Honeypot.getGUI().create("Honeypots {currentPage}/{maxPage}", 3);
 
-		for (HoneypotBlockObject honeypotBlock : Honeypot.getHBM().getAllHoneypots()) {
+		for (HoneypotBlockObject honeypotBlock : Honeypot.getBlockManager().getAllHoneypots()) {
 			GUIItemBuilder item;
 
 			if (Boolean.TRUE.equals(HoneypotConfigManager.getGuiConfig().getBoolean("display-button-as-honeypot"))) {
@@ -207,7 +207,7 @@ public class HoneypotGUI implements HoneypotSubCommand {
 
 		GUIButton removeAllButton = new GUIButton(removeAllItem.build()).withListener((InventoryClickEvent event) -> {
 			event.getWhoClicked().closeInventory();
-			Honeypot.getHBM().deleteAllHoneypotBlocks();
+			Honeypot.getBlockManager().deleteAllHoneypotBlocks();
 			p.sendMessage(CommandFeedback.sendCommandFeedback("deletedall"));
 		});
 
@@ -229,8 +229,8 @@ public class HoneypotGUI implements HoneypotSubCommand {
 						final Block b = new Location(p.getWorld(), x, y, z).getBlock();
 
 						// If it is a honeypot do this
-						if (Boolean.TRUE.equals(Honeypot.getHBM().isHoneypotBlock(b))) {
-							Honeypot.getHBM().deleteBlock(b);
+						if (Boolean.TRUE.equals(Honeypot.getBlockManager().isHoneypotBlock(b))) {
+							Honeypot.getBlockManager().deleteBlock(b);
 
 						}
 					}
@@ -258,8 +258,8 @@ public class HoneypotGUI implements HoneypotSubCommand {
 						return;
 					}
 
-					if (Boolean.TRUE.equals(Honeypot.getHBM().isHoneypotBlock(block))) {
-						Honeypot.getHBM().deleteBlock(block);
+					if (Boolean.TRUE.equals(Honeypot.getBlockManager().isHoneypotBlock(block))) {
+						Honeypot.getBlockManager().deleteBlock(block);
 						p.sendMessage(CommandFeedback.sendCommandFeedback("success", false));
 					}
 					else {
@@ -338,7 +338,7 @@ public class HoneypotGUI implements HoneypotSubCommand {
 		}
 
 		event.getWhoClicked().closeInventory();
-		if (Boolean.TRUE.equals(Honeypot.getHBM().isHoneypotBlock(block))) {
+		if (Boolean.TRUE.equals(Honeypot.getBlockManager().isHoneypotBlock(block))) {
 			event.getWhoClicked().sendMessage(CommandFeedback.sendCommandFeedback("alreadyexists"));
 
 			// If it does not have a honeypot tag or the honeypot tag does not equal 1, create one
@@ -353,11 +353,11 @@ public class HoneypotGUI implements HoneypotSubCommand {
 				return;
 
 			if (action.equalsIgnoreCase("custom")) {
-				Honeypot.getHBM().createBlock(block, customAction[0]);
+				Honeypot.getBlockManager().createBlock(block, customAction[0]);
 				event.getWhoClicked().sendMessage(CommandFeedback.sendCommandFeedback("success", true));
 			}
 			else {
-				Honeypot.getHBM().createBlock(event.getWhoClicked().getTargetBlockExact(5), action);
+				Honeypot.getBlockManager().createBlock(event.getWhoClicked().getTargetBlockExact(5), action);
 				event.getWhoClicked().sendMessage(CommandFeedback.sendCommandFeedback("success", true));
 			}
 
@@ -421,7 +421,7 @@ public class HoneypotGUI implements HoneypotSubCommand {
 						final Block b = new Location(p.getWorld(), x, y, z).getBlock();
 
 						// If it is a honeypot do this
-						if (Boolean.TRUE.equals(Honeypot.getHBM().isHoneypotBlock(b))) {
+						if (Boolean.TRUE.equals(Honeypot.getBlockManager().isHoneypotBlock(b))) {
 							potFound = true;
 
 							// Create a dumb, invisible, invulnerable, block-sized glowing slime and spawn

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotHistory.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotHistory.java
@@ -13,6 +13,11 @@ import org.reprogle.honeypot.commands.CommandFeedback;
 import org.reprogle.honeypot.commands.HoneypotSubCommand;
 import org.reprogle.honeypot.storagemanager.HoneypotPlayerHistoryObject;
 
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.chat.hover.content.Text;
+
 @SuppressWarnings({"java:S1192", "java:S3776"})
 public class HoneypotHistory implements HoneypotSubCommand{
 
@@ -60,10 +65,14 @@ public class HoneypotHistory implements HoneypotSubCommand{
                 }
 
                 for (int i = 0; i < limit; i++) {
-                    p.sendMessage(ChatColor.GOLD + "---[ " + ChatColor.WHITE + history.get(i).getDateTime() + ChatColor.GOLD + " ]---");
-                    p.sendMessage("Player: " + ChatColor.GOLD + history.get(i).getPlayer() + ChatColor.WHITE + " @ " + ChatColor.WHITE + ChatColor.GOLD + history.get(i).getHoneypot().getWorld() + " " + history.get(i).getHoneypot().getCoordinates());
+                    p.sendMessage(ChatColor.GOLD + "\n-------[ " + ChatColor.WHITE + history.get(i).getDateTime() + ChatColor.GOLD + " ]-------");
+                    TextComponent playerInfo = new TextComponent("Player: " + ChatColor.GOLD + history.get(i).getPlayer() + ChatColor.WHITE + " @ " + ChatColor.WHITE + ChatColor.GOLD + history.get(i).getHoneypot().getWorld() + " " + history.get(i).getHoneypot().getCoordinates());
+                    playerInfo.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/hpteleport " + (history.get(i).getHoneypot().getLocation().getX() + 0.5) + " " + (history.get(i).getHoneypot().getLocation().getY() + 1) + " " + (history.get(i).getHoneypot().getLocation().getZ() + 0.5)));
+                    playerInfo.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(ChatColor.GRAY + "" + ChatColor.ITALIC + "Click to teleport")));
+
+                    p.spigot().sendMessage(playerInfo);
                     p.sendMessage("Action: " + ChatColor.GOLD + history.get(i).getHoneypot().getAction());
-                    p.sendMessage(ChatColor.GOLD + "-------------------------\n");
+                    p.sendMessage(ChatColor.GOLD + "----------------------------------");
                 }
                 
             } else if (args[1].equalsIgnoreCase("delete")) {

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotHistory.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotHistory.java
@@ -8,10 +8,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.reprogle.honeypot.Honeypot;
-import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.commands.CommandFeedback;
 import org.reprogle.honeypot.commands.HoneypotSubCommand;
 import org.reprogle.honeypot.storagemanager.HoneypotPlayerHistoryObject;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotHistory.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotHistory.java
@@ -1,0 +1,35 @@
+package org.reprogle.honeypot.commands.subcommands;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.entity.Player;
+import org.reprogle.honeypot.commands.HoneypotSubCommand;
+
+public class HoneypotHistory implements HoneypotSubCommand{
+
+    @Override
+    public String getName() {
+        return "history";
+    }
+
+    @Override
+    public void perform(Player p, String[] args) throws IOException {
+        // TODO Auto-generated method stub
+        
+    }
+
+    @Override
+    public List<String> getSubcommands(Player p, String[] args) {
+        List<String> subcommands = new ArrayList<>();
+
+        if (args.length == 2) {
+            subcommands.add("delete");
+            subcommands.add("query");
+        }
+
+        return subcommands;
+    }
+    
+}

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotInfo.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotInfo.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.reprogle.honeypot.Honeypot;
 import org.reprogle.honeypot.commands.CommandFeedback;
@@ -20,13 +19,9 @@ public class HoneypotInfo implements HoneypotSubCommand {
 
     @Override
     public void perform(Player p, String[] args) throws IOException {
-        p.sendMessage(ChatColor.GOLD + " _____                         _");
-        p.sendMessage(ChatColor.GOLD + "|  |  |___ ___ ___ _ _ ___ ___| |_"); 
-        p.sendMessage(ChatColor.GOLD + "|     | . |   | -_| | | . | . |  _|    by" + ChatColor.RED + " TerrorByte"); 
-        p.sendMessage(ChatColor.GOLD + "|__|__|___|_|_|___|_  |  _|___|_|      version " + ChatColor.RED + Honeypot.getPlugin().getDescription().getVersion());
-        p.sendMessage(ChatColor.GOLD + "                  |___|_|");
+        p.sendMessage(CommandFeedback.getChatPrefix() + " Honeypot version " + Honeypot.getPlugin().getDescription().getVersion());
         
-        p.sendMessage(CommandFeedback.getChatPrefix() + " Honeypot running on Spigot version " + Bukkit.getVersion());
+        p.sendMessage(CommandFeedback.getChatPrefix() + " Running on " + Bukkit.getVersion());
         if (!Honeypot.versionCheck()) {
             p.sendMessage(CommandFeedback.getChatPrefix() + " This version of Honeypot is not guaranteed to work on this version of Spigot. Some newer blocks (If any) may exhibit unusual behavior!");
         }

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotInfo.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotInfo.java
@@ -20,12 +20,12 @@ public class HoneypotInfo implements HoneypotSubCommand {
 
     @Override
     public void perform(Player p, String[] args) throws IOException {
-        p.sendMessage(ChatColor.GOLD + 
-        " _____                         _\n"
-      + "|  |  |___ ___ ___ _ _ ___ ___| |_\n" 
-      + "|     | . |   | -_| | | . | . |  _|    by" + ChatColor.RED + " TerrorByte\n" + ChatColor.GOLD + 
-        "|__|__|___|_|_|___|_  |  _|___|_|      version " + ChatColor.RED + Honeypot.getPlugin().getDescription().getVersion() + "\n" + ChatColor.GOLD + 
-        "                  |___|_|");
+        p.sendMessage(ChatColor.GOLD + " _____                         _");
+        p.sendMessage(ChatColor.GOLD + "|  |  |___ ___ ___ _ _ ___ ___| |_"); 
+        p.sendMessage(ChatColor.GOLD + "|     | . |   | -_| | | . | . |  _|    by" + ChatColor.RED + " TerrorByte"); 
+        p.sendMessage(ChatColor.GOLD + "|__|__|___|_|_|___|_  |  _|___|_|      version " + ChatColor.RED + Honeypot.getPlugin().getDescription().getVersion());
+        p.sendMessage(ChatColor.GOLD + "                  |___|_|");
+        
         p.sendMessage(CommandFeedback.getChatPrefix() + " Honeypot running on Spigot version " + Bukkit.getVersion());
         if (!Honeypot.versionCheck()) {
             p.sendMessage(CommandFeedback.getChatPrefix() + " This version of Honeypot is not guaranteed to work on this version of Spigot. Some newer blocks (If any) may exhibit unusual behavior!");

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotInfo.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotInfo.java
@@ -1,0 +1,40 @@
+package org.reprogle.honeypot.commands.subcommands;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.reprogle.honeypot.Honeypot;
+import org.reprogle.honeypot.commands.CommandFeedback;
+import org.reprogle.honeypot.commands.HoneypotSubCommand;
+
+public class HoneypotInfo implements HoneypotSubCommand {
+
+    @Override
+    public String getName() {
+        return "info";
+    }
+
+    @Override
+    public void perform(Player p, String[] args) throws IOException {
+        p.sendMessage(ChatColor.GOLD + "\n" + 
+        " _____                         _\n"
+      + "|  |  |___ ___ ___ _ _ ___ ___| |_\n" 
+      + "|     | . |   | -_| | | . | . |  _|    by" + ChatColor.RED + " TerrorByte\n" + ChatColor.GOLD + 
+        "|__|__|___|_|_|___|_  |  _|___|_|      version " + ChatColor.RED + Honeypot.getPlugin().getDescription().getVersion() + "\n" + ChatColor.GOLD + 
+        "                  |___|_|");
+        p.sendMessage(CommandFeedback.getChatPrefix() + "Honeypot running on Spigot version " + Bukkit.getVersion());
+        if (!Honeypot.versionCheck()) {
+            p.sendMessage(CommandFeedback.getChatPrefix() + "This version of Honeypot is not guaranteed to work on this version of Spigot. Some newer blocks (If any) may exhibit unusual behavior!");
+        }
+    }
+
+    @Override
+    public List<String> getSubcommands(Player p, String[] args) {
+        return new ArrayList<>();
+    }
+    
+}

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotInfo.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotInfo.java
@@ -20,15 +20,15 @@ public class HoneypotInfo implements HoneypotSubCommand {
 
     @Override
     public void perform(Player p, String[] args) throws IOException {
-        p.sendMessage(ChatColor.GOLD + "\n" + 
+        p.sendMessage(ChatColor.GOLD + 
         " _____                         _\n"
       + "|  |  |___ ___ ___ _ _ ___ ___| |_\n" 
       + "|     | . |   | -_| | | . | . |  _|    by" + ChatColor.RED + " TerrorByte\n" + ChatColor.GOLD + 
         "|__|__|___|_|_|___|_  |  _|___|_|      version " + ChatColor.RED + Honeypot.getPlugin().getDescription().getVersion() + "\n" + ChatColor.GOLD + 
         "                  |___|_|");
-        p.sendMessage(CommandFeedback.getChatPrefix() + "Honeypot running on Spigot version " + Bukkit.getVersion());
+        p.sendMessage(CommandFeedback.getChatPrefix() + " Honeypot running on Spigot version " + Bukkit.getVersion());
         if (!Honeypot.versionCheck()) {
-            p.sendMessage(CommandFeedback.getChatPrefix() + "This version of Honeypot is not guaranteed to work on this version of Spigot. Some newer blocks (If any) may exhibit unusual behavior!");
+            p.sendMessage(CommandFeedback.getChatPrefix() + " This version of Honeypot is not guaranteed to work on this version of Spigot. Some newer blocks (If any) may exhibit unusual behavior!");
         }
     }
 

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotLocate.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotLocate.java
@@ -46,7 +46,7 @@ public class HoneypotLocate implements HoneypotSubCommand {
                     final Block b = new Location(p.getWorld(), x, y, z).getBlock();
 
                     // If it is a honeypot do this
-                    if (Boolean.TRUE.equals(Honeypot.getHBM().isHoneypotBlock(b))) {
+                    if (Boolean.TRUE.equals(Honeypot.getBlockManager().isHoneypotBlock(b))) {
                         potFound = true;
 
                         // Create a dumb, invisible, invulnerable, block-sized glowing slime and spawn it inside the

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotLocate.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotLocate.java
@@ -6,9 +6,9 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.*;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.reprogle.honeypot.Honeypot;
-import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.commands.CommandFeedback;
 import org.reprogle.honeypot.commands.HoneypotSubCommand;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotReload.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotReload.java
@@ -1,9 +1,9 @@
 package org.reprogle.honeypot.commands.subcommands;
 
 import org.bukkit.entity.Player;
-import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.commands.CommandFeedback;
 import org.reprogle.honeypot.commands.HoneypotSubCommand;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotRemove.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotRemove.java
@@ -4,9 +4,9 @@ import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.reprogle.honeypot.Honeypot;
-import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.commands.CommandFeedback;
 import org.reprogle.honeypot.commands.HoneypotSubCommand;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotRemove.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotRemove.java
@@ -64,9 +64,7 @@ public class HoneypotRemove implements HoneypotSubCommand {
                 p.sendMessage(CommandFeedback.sendCommandFeedback("deletednear"));
             }
 
-            default -> {
-                potRemovalCheck(block, p);
-            }
+            default -> potRemovalCheck(block, p);
             }
         }
         else {

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotRemove.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotRemove.java
@@ -32,7 +32,7 @@ public class HoneypotRemove implements HoneypotSubCommand {
         if (args.length >= 2) {
             switch (args[1].toLowerCase()) {
             case "all" -> {
-                Honeypot.getHBM().deleteAllHoneypotBlocks();
+                Honeypot.getBlockManager().deleteAllHoneypotBlocks();
                 p.sendMessage(CommandFeedback.sendCommandFeedback("deletedall"));
             }
 
@@ -53,8 +53,8 @@ public class HoneypotRemove implements HoneypotSubCommand {
                             final Block b = new Location(p.getWorld(), x, y, z).getBlock();
 
                             // If it is a honeypot do this
-                            if (Boolean.TRUE.equals(Honeypot.getHBM().isHoneypotBlock(b))) {
-                                Honeypot.getHBM().deleteBlock(b);
+                            if (Boolean.TRUE.equals(Honeypot.getBlockManager().isHoneypotBlock(b))) {
+                                Honeypot.getBlockManager().deleteBlock(b);
 
                             }
                         }
@@ -89,8 +89,8 @@ public class HoneypotRemove implements HoneypotSubCommand {
 
     private void potRemovalCheck(Block block, Player p) {
         assert block != null;
-        if (Boolean.TRUE.equals(Honeypot.getHBM().isHoneypotBlock(block))) {
-            Honeypot.getHBM().deleteBlock(block);
+        if (Boolean.TRUE.equals(Honeypot.getBlockManager().isHoneypotBlock(block))) {
+            Honeypot.getBlockManager().deleteBlock(block);
             p.sendMessage(CommandFeedback.sendCommandFeedback("success", false));
         }
         else {

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotUpgrade.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotUpgrade.java
@@ -33,7 +33,7 @@ public class HoneypotUpgrade implements HoneypotSubCommand {
 		}
 
 		if (args.length >= 2 && args[1].equalsIgnoreCase("confirm")) {
-			List<HoneypotBlockObject> oldBlocks = Honeypot.getHBM().getAllHoneypots();
+			List<HoneypotBlockObject> oldBlocks = Honeypot.getBlockManager().getAllHoneypots();
 			int customBlock = 0;
 
 			for (HoneypotBlockObject block : oldBlocks) {
@@ -55,8 +55,8 @@ public class HoneypotUpgrade implements HoneypotSubCommand {
 
 					++customBlock;
 
-					Honeypot.getHBM().deleteBlock(block.getBlock());
-					Honeypot.getHBM().createBlock(block.getBlock(), route);
+					Honeypot.getBlockManager().deleteBlock(block.getBlock());
+					Honeypot.getBlockManager().createBlock(block.getBlock(), route);
 				}
 			}
 

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotUpgrade.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/commands/subcommands/HoneypotUpgrade.java
@@ -6,10 +6,10 @@ import java.util.List;
 
 import org.bukkit.entity.Player;
 import org.reprogle.honeypot.Honeypot;
-import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.commands.CommandFeedback;
 import org.reprogle.honeypot.commands.HoneypotSubCommand;
 import org.reprogle.honeypot.storagemanager.HoneypotBlockObject;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 
 @SuppressWarnings("java:S1192")
 public class HoneypotUpgrade implements HoneypotSubCommand {

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/BlockBreakEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/BlockBreakEventListener.java
@@ -12,11 +12,11 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
-import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.Honeypot;
 import org.reprogle.honeypot.api.events.HoneypotPlayerBreakEvent;
 import org.reprogle.honeypot.api.events.HoneypotPrePlayerBreakEvent;
 import org.reprogle.honeypot.commands.CommandFeedback;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 import org.reprogle.honeypot.utils.PhysicsUtil;
 
 import dev.dejvokep.boostedyaml.YamlDocument;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/BlockBreakEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/BlockBreakEventListener.java
@@ -40,14 +40,14 @@ public class BlockBreakEventListener implements Listener {
     @EventHandler(priority = EventPriority.LOW)
     @SuppressWarnings( {"java:S3776", "java:S1192"} )
     public static void blockBreakEvent(BlockBreakEvent event) {
-        if (Boolean.TRUE.equals(Honeypot.getHBM().isHoneypotBlock(event.getBlock()))) {
+        if (Boolean.TRUE.equals(Honeypot.getBlockManager().isHoneypotBlock(event.getBlock()))) {
             // Fire HoneypotPrePlayerBreakEvent
             HoneypotPrePlayerBreakEvent hppbe = new HoneypotPrePlayerBreakEvent(event.getPlayer(), event.getBlock());
             Bukkit.getPluginManager().callEvent(hppbe);
 
             // Check if the event was cancelled. If it is, delete the block.
             if (hppbe.isCancelled()) {
-                Honeypot.getHBM().deleteBlock(event.getBlock());
+                Honeypot.getBlockManager().deleteBlock(event.getBlock());
                 return;
             }
 
@@ -90,7 +90,7 @@ public class BlockBreakEventListener implements Listener {
             // If we flagged the block for deletion, remove it from the DB. Do this after other actions have been
             // completed, otherwise the other actions will fail with NPEs
             if (deleteBlock) {
-                Honeypot.getHBM().deleteBlock(event.getBlock());
+                Honeypot.getBlockManager().deleteBlock(event.getBlock());
             }
         }
     }
@@ -121,9 +121,9 @@ public class BlockBreakEventListener implements Listener {
         for (Block adjacentBlock : adjacentBlocks) {
             if (!PhysicsUtil.getSidePhysics().contains(adjacentBlock.getType())) continue;
 
-            if (Honeypot.getHBM().isHoneypotBlock(adjacentBlock)) {
+            if (Honeypot.getBlockManager().isHoneypotBlock(adjacentBlock)) {
                 blockBreakEvent(new BlockBreakEvent(adjacentBlock, event.getPlayer()));
-                Honeypot.getHBM().deleteBlock(adjacentBlock);
+                Honeypot.getBlockManager().deleteBlock(adjacentBlock);
                 Honeypot.getPlugin().getLogger().warning(
                         "A Honeypot has been removed due to the block it's attached to being broken. It was located at "
                                 + adjacentBlock.getX() + ", " + adjacentBlock.getY() + ", " + adjacentBlock.getZ()
@@ -138,9 +138,9 @@ public class BlockBreakEventListener implements Listener {
         }
 
         // Now check the block on the top (This is important because there are less blocks that can be anchored on the sides of blocks than on the top of blocks)
-        if (PhysicsUtil.getUpPhysics().contains(blockUp.getType()) && Honeypot.getHBM().isHoneypotBlock(blockUp)) {
+        if (PhysicsUtil.getUpPhysics().contains(blockUp.getType()) && Honeypot.getBlockManager().isHoneypotBlock(blockUp)) {
             blockBreakEvent(new BlockBreakEvent(blockUp, event.getPlayer()));
-            Honeypot.getHBM().deleteBlock(blockUp);
+            Honeypot.getBlockManager().deleteBlock(blockUp);
             Honeypot.getPlugin().getLogger().warning(
                     "A Honeypot has been removed due to the block it's attached to being broken. It was located at "
                             + blockUp.getX() + ", " + blockUp.getY() + ", " + blockUp.getZ()
@@ -165,10 +165,11 @@ public class BlockBreakEventListener implements Listener {
         if (!(event.getPlayer().hasPermission(EXEMPT_PERMISSION) || event.getPlayer().hasPermission(REMOVE_PERMISSION)
                 || event.getPlayer().hasPermission(WILDCARD_PERMISSION) || event.getPlayer().isOp())) {
 
-            // TODO - Log block breaks in the history (Need to create a class for handling this)
+            // Log the event in the history table
+            Honeypot.getPlayerHistoryManager().addPlayerHistory(event.getPlayer(), Honeypot.getBlockManager().getHoneypotBlock(event.getBlock()));
 
             // Grab the action from the block via the storage manager
-            String action = Honeypot.getHBM().getAction(block);
+            String action = Honeypot.getBlockManager().getAction(block);
 
             // Run certain actions based on the action of the Honeypot Block
             assert action != null;
@@ -307,11 +308,11 @@ public class BlockBreakEventListener implements Listener {
 
         // Get the config value and the amount of blocks broken
         int breaksBeforeAction = HoneypotConfigManager.getPluginConfig().getInt("blocks-broken-before-action-taken");
-        int blocksBroken = Honeypot.getHPM().getCount(event.getPlayer());
+        int blocksBroken = Honeypot.getPlayerManager().getCount(event.getPlayer());
 
         // getCount returns -1 if the player doesn't exist in the DB. If that's the case, add the player to the DB
         if (blocksBroken == -1) {
-            Honeypot.getHPM().addPlayer(event.getPlayer(), 0);
+            Honeypot.getPlayerManager().addPlayer(event.getPlayer(), 0);
             blocksBroken = 0;
         }
 
@@ -322,12 +323,12 @@ public class BlockBreakEventListener implements Listener {
         // 1,
         // reset the count and perform the break
         if (blocksBroken >= breaksBeforeAction || breaksBeforeAction == 1) {
-            Honeypot.getHPM().setPlayerCount(event.getPlayer(), 0);
+            Honeypot.getPlayerManager().setPlayerCount(event.getPlayer(), 0);
             breakAction(event);
         }
         else {
             // Just count it
-            Honeypot.getHPM().setPlayerCount(event.getPlayer(), blocksBroken);
+            Honeypot.getPlayerManager().setPlayerCount(event.getPlayer(), blocksBroken);
         }
     }
 

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/BlockBreakEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/BlockBreakEventListener.java
@@ -165,6 +165,8 @@ public class BlockBreakEventListener implements Listener {
         if (!(event.getPlayer().hasPermission(EXEMPT_PERMISSION) || event.getPlayer().hasPermission(REMOVE_PERMISSION)
                 || event.getPlayer().hasPermission(WILDCARD_PERMISSION) || event.getPlayer().isOp())) {
 
+            // TODO - Log block breaks in the history (Need to create a class for handling this)
+
             // Grab the action from the block via the storage manager
             String action = Honeypot.getHBM().getAction(block);
 

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/BlockBurnEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/BlockBurnEventListener.java
@@ -22,7 +22,7 @@ public class BlockBurnEventListener implements Listener {
 	public static void onBlockBurnEvent(BlockBurnEvent event) {
 		Block block = event.getBlock();
 
-		if (Honeypot.getHBM().isHoneypotBlock(block)) {
+		if (Honeypot.getBlockManager().isHoneypotBlock(block)) {
 			Honeypot.getHoneypotLogger().log("BlockBurnEvent being called for Honeypot: " + block.getX() + ", " + block.getY() + ", " + block.getZ());
 			event.setCancelled(true);
 

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/BlockFromToEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/BlockFromToEventListener.java
@@ -23,7 +23,7 @@ public class BlockFromToEventListener implements Listener{
     @EventHandler(priority = EventPriority.LOW)
     public static void blockFromToEvent(BlockFromToEvent event) {
       Block toBlock = event.getToBlock();
-      if (Honeypot.getHBM().isHoneypotBlock(toBlock)) {
+      if (Honeypot.getBlockManager().isHoneypotBlock(toBlock)) {
         Honeypot.getHoneypotLogger().log("BlockFromToEvent being called for Honeypot: " + toBlock.getX() + ", " + toBlock.getY() + ", " + toBlock.getZ());
         event.setCancelled(true);
       }

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/EntityChangeBlockEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/EntityChangeBlockEventListener.java
@@ -7,8 +7,8 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.reprogle.honeypot.Honeypot;
-import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.api.events.HoneypotNonPlayerBreakEvent;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 
 public class EntityChangeBlockEventListener implements Listener {
 

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/EntityChangeBlockEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/EntityChangeBlockEventListener.java
@@ -26,7 +26,7 @@ public class EntityChangeBlockEventListener implements Listener {
         // If the entity grabbing the block is an enderman, if they are allowed to, delete the
         // Honeypot, otherwise cancel it
         if (event.getEntity().getType().equals(EntityType.ENDERMAN)) {
-            if (Boolean.TRUE.equals(Honeypot.getHBM().isHoneypotBlock(event.getBlock()))) {
+            if (Boolean.TRUE.equals(Honeypot.getBlockManager().isHoneypotBlock(event.getBlock()))) {
 
                 Honeypot.getHoneypotLogger().log("EntityChangeBlockEvent being called for Honeypot: " + event.getBlock().getX() + ", " + event.getBlock().getY() + ", " + event.getBlock().getZ());
 
@@ -36,7 +36,7 @@ public class EntityChangeBlockEventListener implements Listener {
                 Bukkit.getPluginManager().callEvent(hnpbe);
 
                 if (Boolean.TRUE.equals(HoneypotConfigManager.getPluginConfig().getBoolean("allow-enderman"))) {
-                    Honeypot.getHBM().deleteBlock(event.getBlock());
+                    Honeypot.getBlockManager().deleteBlock(event.getBlock());
                 }
                 else {
                     event.setCancelled(true);
@@ -44,7 +44,7 @@ public class EntityChangeBlockEventListener implements Listener {
             }
         }
         else if (event.getEntity().getType().equals(EntityType.SILVERFISH)
-                && Boolean.TRUE.equals(Honeypot.getHBM().isHoneypotBlock(event.getBlock()))) {
+                && Boolean.TRUE.equals(Honeypot.getBlockManager().isHoneypotBlock(event.getBlock()))) {
 
             // Fire HoneypotNonPlayerBreakEvent
             HoneypotNonPlayerBreakEvent hnpbe = new HoneypotNonPlayerBreakEvent(event.getEntity(), event.getBlock());

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/EntityExplodeEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/EntityExplodeEventListener.java
@@ -11,8 +11,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.reprogle.honeypot.Honeypot;
-import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.api.events.HoneypotNonPlayerBreakEvent;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/EntityExplodeEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/EntityExplodeEventListener.java
@@ -2,6 +2,9 @@ package org.reprogle.honeypot.events;
 
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.TNTPrimed;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -29,19 +32,31 @@ public class EntityExplodeEventListener implements Listener {
         List<Block> destroyedBlocks = event.blockList();
         ArrayList<Block> foundHoneypotBlocks = new ArrayList<>();
         boolean allowExplosions = HoneypotConfigManager.getPluginConfig().getBoolean("allow-explode");
+        Entity e = event.getEntity(); 
+        Entity source = null;
+
+        if (e instanceof TNTPrimed) {
+            TNTPrimed tnt = (TNTPrimed) e;
+            source = tnt.getSource();
+        }
 
         // For every block, check if it was a Honeypot. If it was, check if explosions are allowed.
         // If so, just delete the Honeypot. If not, cancel the explosion
         for (Block block : destroyedBlocks) {
-            if (Boolean.TRUE.equals(Honeypot.getHBM().isHoneypotBlock(block))) {
+            if (Boolean.TRUE.equals(Honeypot.getBlockManager().isHoneypotBlock(block))) {
                 Honeypot.getHoneypotLogger().log("EntityExplodeEvent being called for Honeypot: " + block.getX() + ", " + block.getY() + ", " + block.getZ());
+
+                if (source instanceof Player) {
+                    Honeypot.getPlayerHistoryManager().addPlayerHistory((Player) source, Honeypot.getBlockManager().getHoneypotBlock(block));
+                    Honeypot.getHoneypotLogger().log("EntityExplodeEvent was caused by a player! It has been logged in the history. Player was: " + ((Player) source).getName());
+                }
 
                 // Fire HoneypotNonPlayerBreakEvent
                 HoneypotNonPlayerBreakEvent hnpbe = new HoneypotNonPlayerBreakEvent(event.getEntity(), block);
                 Bukkit.getPluginManager().callEvent(hnpbe);
 
                 if (allowExplosions) {
-                    Honeypot.getHBM().deleteBlock(block);
+                    Honeypot.getBlockManager().deleteBlock(block);
                 }
                 else {
                     foundHoneypotBlocks.add(block);

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/EntityExplodeEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/EntityExplodeEventListener.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.TNTPrimed;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.reprogle.honeypot.Honeypot;
 import org.reprogle.honeypot.HoneypotConfigManager;
@@ -48,7 +49,11 @@ public class EntityExplodeEventListener implements Listener {
 
                 if (source instanceof Player) {
                     Honeypot.getPlayerHistoryManager().addPlayerHistory((Player) source, Honeypot.getBlockManager().getHoneypotBlock(block));
-                    Honeypot.getHoneypotLogger().log("EntityExplodeEvent was caused by a player! It has been logged in the history. Player was: " + ((Player) source).getName());
+                    Honeypot.getHoneypotLogger().log("EntityExplodeEvent was caused by a player! It has been logged in the history, and the Honeypot's action has been triggered for that player. Player was: " + ((Player) source).getName());
+                    
+                    // Call a BlockBreakEvent for that player, as they attempted to break the block in the first place.
+                    BlockBreakEvent blockBreakEvent = new BlockBreakEvent(block, (Player) source);
+                    Bukkit.getPluginManager().callEvent(blockBreakEvent);
                 }
 
                 // Fire HoneypotNonPlayerBreakEvent

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/ListenerSetup.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/ListenerSetup.java
@@ -25,6 +25,7 @@ public class ListenerSetup {
         plugin.getServer().getPluginManager().registerEvents(new PlayerInteractEventListener(), plugin);
         plugin.getServer().getPluginManager().registerEvents(new PlayerJoinEventListener(), plugin);
         plugin.getServer().getPluginManager().registerEvents(new StructureGrowEventListener(), plugin);
+        plugin.getServer().getPluginManager().registerEvents(new PlayerCommandPreprocessEventListener(), plugin);
     }
 
 }

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/PistonExtendRetractListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/PistonExtendRetractListener.java
@@ -26,7 +26,7 @@ public class PistonExtendRetractListener implements Listener {
     public static void pistonPushEvent(BlockPistonExtendEvent event) {
         List<Block> blocks = event.getBlocks();
         for (Block b : blocks) {
-            if (Boolean.TRUE.equals(Honeypot.getHBM().isHoneypotBlock(b))) {
+            if (Boolean.TRUE.equals(Honeypot.getBlockManager().isHoneypotBlock(b))) {
                 Honeypot.getHoneypotLogger().log("PistonExtendEvent being called for Honeypot: " + b.getX() + ", " + b.getY() + "," + b.getZ());
 
                 // Fire HoneypotNonPlayerBreakEvent
@@ -43,7 +43,7 @@ public class PistonExtendRetractListener implements Listener {
     public static void pistonPullEvent(BlockPistonRetractEvent event) {
         List<Block> blocks = event.getBlocks();
         for (Block b : blocks) {
-            if (Boolean.TRUE.equals(Honeypot.getHBM().isHoneypotBlock(b))) {
+            if (Boolean.TRUE.equals(Honeypot.getBlockManager().isHoneypotBlock(b))) {
                 Honeypot.getHoneypotLogger().log("PistonRetractEvent being called for Honeypot: " + b.getX() + ", " + b.getY() + ", " + b.getZ());
 
                 // Fire HoneypotNonPlayerBreakEvent

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/PlayerCommandPreprocessEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/PlayerCommandPreprocessEventListener.java
@@ -1,0 +1,29 @@
+package org.reprogle.honeypot.events;
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+
+public class PlayerCommandPreprocessEventListener implements Listener {
+    
+    /**
+     * Create private constructor to hide the implicit one
+     */
+    PlayerCommandPreprocessEventListener() {
+
+    }
+
+    @EventHandler(priority = EventPriority.LOW)
+    public static void playerCommandPreprocessEvent(PlayerCommandPreprocessEvent event) {
+        if (event.getMessage().startsWith("/hpteleport")) {
+            event.setCancelled(true);
+            String rawCommand = event.getMessage();
+            String processedCommand = rawCommand.replace("/hpteleport", "minecraft:tp " + event.getPlayer().getName());
+
+            Bukkit.dispatchCommand(Bukkit.getServer().getConsoleSender(), processedCommand);
+        }
+    }
+
+}

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/PlayerInteractEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/PlayerInteractEventListener.java
@@ -12,11 +12,11 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.Honeypot;
 import org.reprogle.honeypot.api.events.HoneypotPlayerInteractEvent;
 import org.reprogle.honeypot.api.events.HoneypotPrePlayerInteractEvent;
 import org.reprogle.honeypot.commands.CommandFeedback;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 
 import java.util.List;
 import java.util.Objects;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/PlayerInteractEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/PlayerInteractEventListener.java
@@ -65,7 +65,7 @@ public class PlayerInteractEventListener implements Listener {
 
         try {
             if (!Objects.requireNonNull(event.getPlayer().getTargetBlockExact(5)).getType().equals(Material.ENDER_CHEST)
-                    && Boolean.TRUE.equals(Honeypot.getHBM()
+                    && Boolean.TRUE.equals(Honeypot.getBlockManager()
                             .isHoneypotBlock(Objects.requireNonNull(event.getPlayer().getTargetBlockExact(5))))) {
                 // Fire HoneypotPrePlayerInteractEvent
                 HoneypotPrePlayerInteractEvent hppie = new HoneypotPrePlayerInteractEvent(event.getPlayer(),
@@ -99,7 +99,7 @@ public class PlayerInteractEventListener implements Listener {
         Player player = event.getPlayer();
 
         assert block != null;
-        String action = Honeypot.getHBM().getAction(block);
+        String action = Honeypot.getBlockManager().getAction(block);
 
         assert action != null;
         Honeypot.getHoneypotLogger().log("PlayerInteractEvent being called for player: " + event.getPlayer().getName() + ", UUID of " + event.getPlayer().getUniqueId() + ". Action is: " + action);

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/PlayerJoinEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/PlayerJoinEventListener.java
@@ -10,8 +10,8 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.reprogle.honeypot.Honeypot;
-import org.reprogle.honeypot.HoneypotUpdateChecker;
 import org.reprogle.honeypot.commands.CommandFeedback;
+import org.reprogle.honeypot.utils.HoneypotUpdateChecker;
 
 public class PlayerJoinEventListener implements Listener {
 

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/PlayerJoinEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/PlayerJoinEventListener.java
@@ -28,9 +28,9 @@ public class PlayerJoinEventListener implements Listener {
         Player p = event.getPlayer();
 
         // Convert player names to UUIDs
-        int breaks = Honeypot.getHPM().getCount(p);
+        int breaks = Honeypot.getPlayerManager().getCount(p);
         if (breaks >= 0) {
-            Honeypot.getHPM().setPlayerCount(p, breaks);
+            Honeypot.getPlayerManager().setPlayerCount(p, breaks);
         }
 
         if (p.hasPermission("honeypot.update") || p.hasPermission("honeypot.*") || p.isOp()) {

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/events/StructureGrowEventListener.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/events/StructureGrowEventListener.java
@@ -21,7 +21,7 @@ public class StructureGrowEventListener implements Listener {
 		for (int i = 0; i < event.getBlocks().size(); i++) {
 			BlockState block = event.getBlocks().get(i);
 
-			if (Honeypot.getHBM().isHoneypotBlock(block.getBlock())) {
+			if (Honeypot.getBlockManager().isHoneypotBlock(block.getBlock())) {
 				Honeypot.getHoneypotLogger().log("StuctureGrowEvent being cancelled for Honeypot located at " + block.getX() + ", " + block.getY() + ", " + block.getZ());
 				event.setCancelled(true);
 			}

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/gui/GUI.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/gui/GUI.java
@@ -7,12 +7,12 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.gui.button.GUIButton;
 import org.reprogle.honeypot.gui.item.GUIItemBuilder;
 import org.reprogle.honeypot.gui.menu.GUIMenuListener;
 import org.reprogle.honeypot.gui.menu.GUIOpenMenu;
 import org.reprogle.honeypot.gui.pagination.GUIPageButtonBuilder;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 
 public class GUI {
 

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/CacheManager.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/CacheManager.java
@@ -3,7 +3,7 @@ package org.reprogle.honeypot.storagemanager;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.reprogle.honeypot.HoneypotConfigManager;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 
 /**
  * A rudimentary caching utility to lessen dependency on databases used by Honeypot

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/HoneypotBlockManager.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/HoneypotBlockManager.java
@@ -66,12 +66,31 @@ public class HoneypotBlockManager {
     }
 
     /**
+     * Get the Honeypot Block object from Cache or the DB
+     * @param block The Block to retrieve as a Honeypot Block Object
+     * @return The Honeypot Block Object if it exists, null if it doesn't
+     */
+    public HoneypotBlockObject getHoneypotBlock(Block block) {
+
+        if(Boolean.TRUE.equals(isHoneypotBlock(block)))  
+            return new HoneypotBlockObject(block, getAction(block));
+        
+        return null;
+    }
+
+    /**
      * Return the action for the honeypot {@link Block}
      * 
      * @param block The Block we're checking
      * @return The Honeypot's action as a string
      */
     public String getAction(Block block) {
+        // Check if block exists in cache. If it doesn't this will be null
+        HoneypotBlockObject potential = CacheManager.isInCache(new HoneypotBlockObject(block, null));
+
+        if (potential != null) 
+            return potential.getAction();
+
         Database db;
 
         db = new SQLite(Honeypot.getPlugin());

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/HoneypotPlayerHistory.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/HoneypotPlayerHistory.java
@@ -1,0 +1,102 @@
+package org.reprogle.honeypot.storagemanager;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+
+public class HoneypotPlayerHistory {
+    private String dateTime;
+    private String player;
+    private String UUID;
+    private HoneypotBlockObject hbo;
+
+    /**
+     * @param dateTime
+     * @param player
+     * @param coordinates
+     * @param world
+     * @param action
+     */
+    public HoneypotPlayerHistory(String dateTime, String player, String UUID, String coordinates, String world, String action) {
+        this.dateTime = dateTime;
+        this.player = player;
+        this.UUID = UUID;
+        this.hbo = new HoneypotBlockObject(world, coordinates, action);
+    }
+
+    /**
+     * @param dateTime
+     * @param player
+     * @param hbo
+     */
+    public HoneypotPlayerHistory(String dateTime, String player, String UUID, HoneypotBlockObject hbo) {
+        this.dateTime = dateTime;
+        this.player = player;
+        this.UUID = UUID;
+        this.hbo = hbo;
+    }
+
+    /**
+     * @param dateTime
+     * @param player
+     * @param block
+     * @param action
+     */
+    public HoneypotPlayerHistory(String dateTime, String player, String UUID, Block block, String action) {
+        this.dateTime = dateTime;
+        this.player = player;
+        this.UUID = UUID;
+        this.hbo = new HoneypotBlockObject(block, action);
+    }
+
+    /**
+     * @param dateTime
+     * @param player
+     * @param block
+     * @param action
+     */
+    public HoneypotPlayerHistory(String dateTime, Player player, Block block, String action) {
+        this.dateTime = dateTime;
+        this.player = player.getName();
+        this.UUID = player.getUniqueId().toString();
+        this.hbo = new HoneypotBlockObject(block, action);
+    }
+
+    /**
+     * @param dateTime
+     * @param player
+     * @param hbo
+     */
+    public HoneypotPlayerHistory(String dateTime, Player player, HoneypotBlockObject hbo) {
+        this.dateTime = dateTime;
+        this.player = player.getName();
+        this.UUID = player.getUniqueId().toString();
+        this.hbo = hbo;
+    }
+
+    /**
+     * @return
+     */
+    public String getDateTime() {
+        return dateTime;
+    }
+
+    /**
+     * @return
+     */
+    public String getPlayer() {
+        return player;
+    }
+
+    public String getUUID() {
+        return UUID;
+    }
+
+    /**
+     * @return
+     */
+    public HoneypotBlockObject getHoneypot() {
+        return hbo;
+    }
+
+    
+}

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/HoneypotPlayerHistoryManager.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/HoneypotPlayerHistoryManager.java
@@ -1,0 +1,70 @@
+package org.reprogle.honeypot.storagemanager;
+
+import java.util.List;
+
+import org.bukkit.entity.Player;
+import org.reprogle.honeypot.Honeypot;
+import org.reprogle.honeypot.storagemanager.sqlite.Database;
+import org.reprogle.honeypot.storagemanager.sqlite.SQLite;
+
+public class HoneypotPlayerHistoryManager {
+
+    /**
+     * Add an entry to the player history table
+     * @param p The player to add
+     * @param b The honeypot block they triggered
+     */
+    public void addPlayerHistory(Player p, HoneypotBlockObject b) {
+        Database db;
+        db = new SQLite(Honeypot.getPlugin());
+        db.load();
+
+        db.addPlayerHistory(p, b);
+
+        Honeypot.getHoneypotLogger().log("Added new history entry for player " + p.getName());
+    }
+
+    /**
+     * Get the history for a player
+     * @param p The player to grab history for
+     * @return A list of all HoneypotPlayerHistory objects
+     */
+    public List<HoneypotPlayerHistoryObject> getPlayerHistory(Player p) {
+        Database db;
+        db = new SQLite(Honeypot.getPlugin());
+        db.load();
+
+        return db.retrieveHistory(p);
+    }
+
+    /**
+     * Delete all history for a particular player. An optional n parameter for specifying the number of most recent rows to delete
+     * @param p The player to delete
+     * @param n Optional, the number of most recent rows
+     */
+    public void deletePlayerHistory (Player p, int... n) {
+        Database db;
+        db = new SQLite(Honeypot.getPlugin());
+        db.load();
+
+        if (n != null) {
+            db.deletePlayerHistory(p, n);
+        } else {
+            db.deletePlayerHistory(p);
+        }
+
+        Honeypot.getHoneypotLogger().log("Deleting player history for player " + p.getName());
+    }
+
+    /**
+     * A function to purge the entire history table
+     */
+    public void deleteAllHistory() {
+        Database db;
+        db = new SQLite(Honeypot.getPlugin());
+        db.load();
+
+        db.deleteAllHistory();
+    }
+
+}

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/HoneypotPlayerHistoryManager.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/HoneypotPlayerHistoryManager.java
@@ -7,6 +7,11 @@ import org.reprogle.honeypot.Honeypot;
 import org.reprogle.honeypot.storagemanager.sqlite.Database;
 import org.reprogle.honeypot.storagemanager.sqlite.SQLite;
 
+/**
+ * A class for managing Honeypot history entries.
+ * Adds functions for creating, removing, querying, and purging the history database. 
+ * @see HoneypotPlayerHistoryObject
+ */
 public class HoneypotPlayerHistoryManager {
 
     /**
@@ -47,7 +52,7 @@ public class HoneypotPlayerHistoryManager {
         db = new SQLite(Honeypot.getPlugin());
         db.load();
 
-        if (n != null) {
+        if (n.length > 0) {
             db.deletePlayerHistory(p, n);
         } else {
             db.deletePlayerHistory(p);

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/HoneypotPlayerHistoryObject.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/HoneypotPlayerHistoryObject.java
@@ -3,7 +3,7 @@ package org.reprogle.honeypot.storagemanager;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
-public class HoneypotPlayerHistory {
+public class HoneypotPlayerHistoryObject {
     private String dateTime;
     private String player;
     private String UUID;
@@ -16,7 +16,7 @@ public class HoneypotPlayerHistory {
      * @param world
      * @param action
      */
-    public HoneypotPlayerHistory(String dateTime, String player, String UUID, String coordinates, String world, String action) {
+    public HoneypotPlayerHistoryObject(String dateTime, String player, String UUID, String coordinates, String world, String action) {
         this.dateTime = dateTime;
         this.player = player;
         this.UUID = UUID;
@@ -28,7 +28,7 @@ public class HoneypotPlayerHistory {
      * @param player
      * @param hbo
      */
-    public HoneypotPlayerHistory(String dateTime, String player, String UUID, HoneypotBlockObject hbo) {
+    public HoneypotPlayerHistoryObject(String dateTime, String player, String UUID, HoneypotBlockObject hbo) {
         this.dateTime = dateTime;
         this.player = player;
         this.UUID = UUID;
@@ -41,7 +41,7 @@ public class HoneypotPlayerHistory {
      * @param block
      * @param action
      */
-    public HoneypotPlayerHistory(String dateTime, String player, String UUID, Block block, String action) {
+    public HoneypotPlayerHistoryObject(String dateTime, String player, String UUID, Block block, String action) {
         this.dateTime = dateTime;
         this.player = player;
         this.UUID = UUID;
@@ -54,7 +54,7 @@ public class HoneypotPlayerHistory {
      * @param block
      * @param action
      */
-    public HoneypotPlayerHistory(String dateTime, Player player, Block block, String action) {
+    public HoneypotPlayerHistoryObject(String dateTime, Player player, Block block, String action) {
         this.dateTime = dateTime;
         this.player = player.getName();
         this.UUID = player.getUniqueId().toString();
@@ -66,7 +66,7 @@ public class HoneypotPlayerHistory {
      * @param player
      * @param hbo
      */
-    public HoneypotPlayerHistory(String dateTime, Player player, HoneypotBlockObject hbo) {
+    public HoneypotPlayerHistoryObject(String dateTime, Player player, HoneypotBlockObject hbo) {
         this.dateTime = dateTime;
         this.player = player.getName();
         this.UUID = player.getUniqueId().toString();

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/HoneypotPlayerHistoryObject.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/HoneypotPlayerHistoryObject.java
@@ -1,27 +1,13 @@
 package org.reprogle.honeypot.storagemanager;
 
-import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
+@SuppressWarnings("java:S116")
 public class HoneypotPlayerHistoryObject {
     private String dateTime;
     private String player;
     private String UUID;
     private HoneypotBlockObject hbo;
-
-    /**
-     * @param dateTime
-     * @param player
-     * @param coordinates
-     * @param world
-     * @param action
-     */
-    public HoneypotPlayerHistoryObject(String dateTime, String player, String UUID, String coordinates, String world, String action) {
-        this.dateTime = dateTime;
-        this.player = player;
-        this.UUID = UUID;
-        this.hbo = new HoneypotBlockObject(world, coordinates, action);
-    }
 
     /**
      * @param dateTime
@@ -33,32 +19,6 @@ public class HoneypotPlayerHistoryObject {
         this.player = player;
         this.UUID = UUID;
         this.hbo = hbo;
-    }
-
-    /**
-     * @param dateTime
-     * @param player
-     * @param block
-     * @param action
-     */
-    public HoneypotPlayerHistoryObject(String dateTime, String player, String UUID, Block block, String action) {
-        this.dateTime = dateTime;
-        this.player = player;
-        this.UUID = UUID;
-        this.hbo = new HoneypotBlockObject(block, action);
-    }
-
-    /**
-     * @param dateTime
-     * @param player
-     * @param block
-     * @param action
-     */
-    public HoneypotPlayerHistoryObject(String dateTime, Player player, Block block, String action) {
-        this.dateTime = dateTime;
-        this.player = player.getName();
-        this.UUID = player.getUniqueId().toString();
-        this.hbo = new HoneypotBlockObject(block, action);
     }
 
     /**

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/HoneypotPlayerHistoryObject.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/HoneypotPlayerHistoryObject.java
@@ -2,6 +2,11 @@ package org.reprogle.honeypot.storagemanager;
 
 import org.bukkit.entity.Player;
 
+/**
+ * A class representing a player history entry. 
+ * Includes methods for getting all values of a Honeypot history entry, which can be returned via the {@link HoneypotPlayerHistoryManager} class
+ * @see HoneypotPlayerHistoryManager
+ */
 @SuppressWarnings("java:S116")
 public class HoneypotPlayerHistoryObject {
     private String dateTime;
@@ -10,9 +15,11 @@ public class HoneypotPlayerHistoryObject {
     private HoneypotBlockObject hbo;
 
     /**
-     * @param dateTime
-     * @param player
-     * @param hbo
+     * Constructor for creating a history entry
+     * @param dateTime The Date and Time in string format. Really need to improve this to have standards but oh well
+     * @param player The player's name
+     * @param UUID The UUID of the player
+     * @param hbo The HoneypotBlockObject they broke
      */
     public HoneypotPlayerHistoryObject(String dateTime, String player, String UUID, HoneypotBlockObject hbo) {
         this.dateTime = dateTime;
@@ -22,9 +29,10 @@ public class HoneypotPlayerHistoryObject {
     }
 
     /**
-     * @param dateTime
-     * @param player
-     * @param hbo
+     * Constructor for creating a history entry
+     * @param dateTime The Date and Time in string format. Really need to improve this to have standards but oh well
+     * @param player The player object
+     * @param hbo The HoneypotBlockObject they broke
      */
     public HoneypotPlayerHistoryObject(String dateTime, Player player, HoneypotBlockObject hbo) {
         this.dateTime = dateTime;
@@ -34,25 +42,31 @@ public class HoneypotPlayerHistoryObject {
     }
 
     /**
-     * @return
+     * Get the date and time of the history entry
+     * @return Date and Time, string formatted and in GMT +0:00
      */
     public String getDateTime() {
         return dateTime;
     }
 
     /**
-     * @return
+     * Get the player's name
+     * @return Player name
      */
     public String getPlayer() {
         return player;
     }
 
+    /**
+     * Get the player's UUID
+     * @return UUID
+     */
     public String getUUID() {
         return UUID;
     }
 
-    /**
-     * @return
+    /** Get the Honeypot they broke
+     * @return {@link HoneypotBlockObject}
      */
     public HoneypotBlockObject getHoneypot() {
         return hbo;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/sqlite/Database.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/sqlite/Database.java
@@ -571,7 +571,8 @@ public abstract class Database {
 
             List<HoneypotPlayerHistoryObject> history = new ArrayList<>();
             while (rs.next()) {
-                history.add(new HoneypotPlayerHistoryObject(rs.getString("datetime"), rs.getString("playerName"), rs.getString("playerUUID"), rs.getString("coordinates"), rs.getString("world"), rs.getString("action")));
+                HoneypotBlockObject hbo = new HoneypotBlockObject(rs.getString("world"), rs.getString("coordinates"), rs.getString("action"));
+                history.add(new HoneypotPlayerHistoryObject(rs.getString("datetime"), rs.getString("playerName"), rs.getString("playerUUID"), hbo));
             }
 
             return history;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/sqlite/Database.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/sqlite/Database.java
@@ -4,7 +4,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.reprogle.honeypot.Honeypot;
 import org.reprogle.honeypot.storagemanager.HoneypotBlockObject;
-import org.reprogle.honeypot.storagemanager.HoneypotPlayerHistory;
+import org.reprogle.honeypot.storagemanager.HoneypotPlayerHistoryObject;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -559,7 +559,7 @@ public abstract class Database {
      * @param p The Player to retrieve
      * @return An ArrayList of HoneypotPlayerHistory objects for the player
      */
-    public List<HoneypotPlayerHistory> retrieveHistory(Player p) {
+    public List<HoneypotPlayerHistoryObject> retrieveHistory(Player p) {
         Connection c = null;
         PreparedStatement ps = null;
         ResultSet rs = null;
@@ -569,9 +569,9 @@ public abstract class Database {
             ps.setString(1, p.getUniqueId().toString());
             rs = ps.executeQuery();
 
-            List<HoneypotPlayerHistory> history = new ArrayList<>();
+            List<HoneypotPlayerHistoryObject> history = new ArrayList<>();
             while (rs.next()) {
-                history.add(new HoneypotPlayerHistory(rs.getString("datetime"), rs.getString("playerName"), rs.getString("playerUUID"), rs.getString("coordinates"), rs.getString("world"), rs.getString("action")));
+                history.add(new HoneypotPlayerHistoryObject(rs.getString("datetime"), rs.getString("playerName"), rs.getString("playerUUID"), rs.getString("coordinates"), rs.getString("world"), rs.getString("action")));
             }
 
             return history;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/sqlite/Database.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/sqlite/Database.java
@@ -605,20 +605,20 @@ public abstract class Database {
 
         try {
             c = getSQLConnection();
-            if (n != null) {
-                //TODO - SQLite is throwing errors here because it doesn't like the Desc keyword
-                ps = c.prepareStatement(DELETE + HISTORY_TABLE + " WHERE playerUUID = ? DESC LIMIT ?;");
+            if (n.length > 0) {
+                ps = c.prepareStatement(DELETE + HISTORY_TABLE + " WHERE rowid IN (SELECT rowid FROM " + HISTORY_TABLE + " WHERE playerUUID = ? ORDER BY rowid DESC LIMIT ?);");
+                ps.setString(1, p.getUniqueId().toString());
                 ps.setInt(2, n[0]);
             } else {
                 ps = c.prepareStatement(DELETE + HISTORY_TABLE + " WHERE playerUUID = ?;");
+                ps.setString(1, p.getUniqueId().toString());
             }
 
-            ps.setString(1, p.getUniqueId().toString());
             ps.executeUpdate();
 
         }
         catch (SQLException e) {
-            Honeypot.getPlugin().getLogger().severe("Error while remove executing SQL statement on block table: " + e);
+            Honeypot.getPlugin().getLogger().severe("Error while executing SQL statement on block table: " + e);
         }
         finally {
             try {

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/sqlite/Database.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/sqlite/Database.java
@@ -606,6 +606,7 @@ public abstract class Database {
         try {
             c = getSQLConnection();
             if (n != null) {
+                //TODO - SQLite is throwing errors here because it doesn't like the Desc keyword
                 ps = c.prepareStatement(DELETE + HISTORY_TABLE + " WHERE playerUUID = ? DESC LIMIT ?;");
                 ps.setInt(2, n[0]);
             } else {

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/sqlite/SQLite.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/storagemanager/sqlite/SQLite.java
@@ -22,18 +22,27 @@ public class SQLite extends Database {
 
     // The queries used to load the DB table. Only runs if the table doesn't exist.
     private static final String SQLITE_CREATE_PLAYERS_TABLE = "CREATE TABLE IF NOT EXISTS honeypot_players (" +
-            "`playerName` varchar(10) NOT NULL," +
-            "`blocksBroken` int(10) NOT NULL," +
+            "`playerName` VARCHAR NOT NULL," +
+            "`blocksBroken` INT NOT NULL," +
             "PRIMARY KEY (`playerName`)" +
         ");";
 
     private static final String SQLITE_CREATE_BLOCKS_TABLE = "CREATE TABLE IF NOT EXISTS honeypot_blocks (" +
-            "`coordinates` varchar(10) NOT NULL," +
-            "`worldName` varchar(10) NOT NULL," +
-            "`action` varchar(10) NOT NULL," +
+            "`coordinates` VARCHAR NOT NULL," +
+            "`worldName` VARCHAR NOT NULL," +
+            "`action` VARCHAR NOT NULL," +
             "PRIMARY KEY (`coordinates`, `worldName`)" +
-            ");";
-
+        ");";
+            
+    //SQLite has this cool feature where if no primary key is provided, the primary key defaults to the rowid. Nifty!
+    private static final String SQLITE_CREATE_HISTORY_TABLE = "CREATE TABLE IF NOT EXISTS honeypot_history (" +
+            "`datetime` VARCHAR NOT NULL," +
+            "`playerName` varchar NOT NULL," +
+            "`playerUUID` VARCHAR NOT NULL," +
+            "`coordinates` VARCHAR NOT NULL,"+
+            "`world` VARCHAR NOT NULL,"+
+            "`action` VARCHAR NOT NULL" +
+        ");";
     /**
      * Get's the DB connection, also verifies if JDBC is installed. If it isn't plugin is disabled as it can't function
      * without it
@@ -86,6 +95,7 @@ public class SQLite extends Database {
         try (Statement s = connection.createStatement()) {
             s.executeUpdate(SQLITE_CREATE_PLAYERS_TABLE);
             s.executeUpdate(SQLITE_CREATE_BLOCKS_TABLE);
+            s.executeUpdate(SQLITE_CREATE_HISTORY_TABLE);
         }
         catch (SQLException e) {
             Honeypot.getPlugin().getLogger().severe("SQLException occured while attempting to create tables if they don't exist: " + e);

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/utils/GhostHoneypotFixer.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/utils/GhostHoneypotFixer.java
@@ -31,12 +31,12 @@ public class GhostHoneypotFixer {
 				Honeypot.getPlugin().getLogger().info("Running ghost Honeypot checks...");
 				Honeypot.getHoneypotLogger().log("Running ghost Honeypot checks...");
 				int removedPots = 0;
-				List<HoneypotBlockObject> pots = Honeypot.getHBM().getAllHoneypots();	
+				List<HoneypotBlockObject> pots = Honeypot.getBlockManager().getAllHoneypots();	
 				for (HoneypotBlockObject pot : pots) {
 					if (pot.getBlock().getType().equals(Material.AIR)) {
 						Honeypot.getPlugin().getLogger().info("Found ghost Honeypot at " + pot.getCoordinates() + ". Removing");
 						Honeypot.getHoneypotLogger().log("Found ghost Honeypot at " + pot.getCoordinates() + ". Removing");
-						Honeypot.getHBM().deleteBlock(pot.getBlock());
+						Honeypot.getBlockManager().deleteBlock(pot.getBlock());
 						removedPots++;
 					}
 				}

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/utils/GhostHoneypotFixer.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/utils/GhostHoneypotFixer.java
@@ -6,7 +6,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.scheduler.BukkitTask;
 import org.reprogle.honeypot.Honeypot;
-import org.reprogle.honeypot.HoneypotConfigManager;
 import org.reprogle.honeypot.storagemanager.HoneypotBlockObject;
 
 @SuppressWarnings({ "java:S1604"})

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/utils/GriefPreventionUtil.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/utils/GriefPreventionUtil.java
@@ -2,7 +2,6 @@ package org.reprogle.honeypot.utils;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
-import org.reprogle.honeypot.HoneypotConfigManager;
 
 import me.ryanhamshire.GriefPrevention.ClaimPermission;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/utils/HoneypotConfigManager.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/utils/HoneypotConfigManager.java
@@ -45,7 +45,6 @@ public class HoneypotConfigManager extends JavaPlugin {
             config.save();
         }
         catch (IOException e) {
-            e.printStackTrace();
             plugin.getLogger().severe(
                     "Could not create/load plugin config, disabling! Please alert the plugin author with the following info: " + e);
             plugin.getPluginLoader().disablePlugin(plugin);

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/utils/HoneypotConfigManager.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/utils/HoneypotConfigManager.java
@@ -1,4 +1,4 @@
-package org.reprogle.honeypot;
+package org.reprogle.honeypot.utils;
 
 import dev.dejvokep.boostedyaml.YamlDocument;
 import dev.dejvokep.boostedyaml.dvs.versioning.BasicVersioning;

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/utils/HoneypotLogger.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/utils/HoneypotLogger.java
@@ -8,7 +8,6 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 import org.reprogle.honeypot.Honeypot;
-import org.reprogle.honeypot.HoneypotConfigManager;
 
 public class HoneypotLogger {
 

--- a/honeypot-core/src/main/java/org/reprogle/honeypot/utils/HoneypotUpdateChecker.java
+++ b/honeypot-core/src/main/java/org/reprogle/honeypot/utils/HoneypotUpdateChecker.java
@@ -1,8 +1,9 @@
-package org.reprogle.honeypot;
+package org.reprogle.honeypot.utils;
 
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.Consumer;
+import org.reprogle.honeypot.Honeypot;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/honeypot-core/src/main/resources/config.yml
+++ b/honeypot-core/src/main/resources/config.yml
@@ -59,6 +59,9 @@ language: en_US
 # If you don't know what this is, leave it set to false
 bypass-language-check: false
 
+# The amount of history entries to return from the '/honeypot history query' command
+history-length: 5
+
 ######################################################################
 #                     F I L T E R   S E T T I N G S                  #
 ######################################################################

--- a/honeypot-core/src/main/resources/config.yml
+++ b/honeypot-core/src/main/resources/config.yml
@@ -51,7 +51,7 @@ enable-logging: true
 #                      C H A T   S E T T I N G S                     #
 ######################################################################
 
-# Select your language. Currently only en_US is supported, with translations coming soon!
+# Select your language. Current supported languages are: [en_US, es_MX]
 # Want to create your own translation? Visit here: https://github.com/TerrrorByte/Honeypot/wiki/Translating-Honeypot
 language: en_US
 

--- a/honeypot-core/src/main/resources/gui.yml
+++ b/honeypot-core/src/main/resources/gui.yml
@@ -3,7 +3,7 @@
 ######################################################################
 
 # File verison (do NOT edit):
-file-version: 4
+file-version: 5
 
 ######################################################################
 #                       G U I   S E T T I N G S                      #
@@ -30,6 +30,7 @@ main-buttons:
   remove-button: DIAMOND_PICKAXE
   list-button: BOOK
   locate-button: SPYGLASS
+  history-button: CLOCK
 
 # The buttons to display in the remove inventory
 remove-buttons:

--- a/honeypot-core/src/main/resources/lang/en_US.yml
+++ b/honeypot-core/src/main/resources/lang/en_US.yml
@@ -1,5 +1,5 @@
 language-version: 2
-prefix: "&b[Honeypot]&r"
+prefix: "&6[Honeypot]&r"
 kick-reason: "Kicked for breaking honeypot blocks. Don't grief!"
 ban-reason: "You have been banned for breaking honeypot blocks"
 warn-message: "Please don't grief builds!"

--- a/honeypot-core/src/main/resources/lang/en_US.yml
+++ b/honeypot-core/src/main/resources/lang/en_US.yml
@@ -1,4 +1,4 @@
-language-version: 1
+language-version: 2
 prefix: "&b[Honeypot]&r"
 kick-reason: "Kicked for breaking honeypot blocks. Don't grief!"
 ban-reason: "You have been banned for breaking honeypot blocks"
@@ -27,3 +27,7 @@ griefprevention: "This area is protected by GriefPrevention, and you don't have 
 unknown-error: "Unknown error. Please contact server admin"
 staff-broke: "Just an FYI this was a honeypot. Since you broke it we've removed it"
 exempt-no-break: "You are exempt from break actions, but do not have permissions to remove honeypot blocks. Sorry!"
+searching: "Searching, please wait..."
+truncating: "Trimming results per config settings..."
+not-online: "&cThis player is not online!"
+no-history: "No history found for this player!"

--- a/honeypot-core/src/main/resources/lang/es_MX.yml
+++ b/honeypot-core/src/main/resources/lang/es_MX.yml
@@ -1,5 +1,5 @@
 language-version: 2
-prefix: "&b[Honeypot]&r"
+prefix: "&6[Honeypot]&r"
 kick-reason: "Pateado por romper bloques de honeypot. ¡No te apenes!"
 ban-reason: "Has sido baneado por romper bloques de honeypot"
 warn-message: "¡Por favor, no se acumule el dolor!"

--- a/honeypot-core/src/main/resources/lang/es_MX.yml
+++ b/honeypot-core/src/main/resources/lang/es_MX.yml
@@ -1,4 +1,4 @@
-language-version: 1
+language-version: 2
 prefix: "&b[Honeypot]&r"
 kick-reason: "Pateado por romper bloques de honeypot. ¡No te apenes!"
 ban-reason: "Has sido baneado por romper bloques de honeypot"
@@ -27,3 +27,7 @@ griefprevention: "Esta área está protegida por GriefPrevention y no tienes per
 unknown-error: "Error desconocido. Póngase en contacto con el administrador del servidor"
 staff-broke: "Solo un FYI esto fue un honeypot. Desde que lo rompiste lo hemos quitado"
 exempt-no-break: "Está exento de acciones de interrupción, pero no tiene permisos para eliminar bloques de trampas. ¡Lo siento!"
+searching: "Buscando, espere por favor..."
+truncating: "Recorte de resultados por ajustes de configuración..."
+not-online: "&cEste jugador no está en línea!"
+no-history: "No se ha encontrado historia para este jugador!"

--- a/honeypot-core/src/main/resources/plugin.yml
+++ b/honeypot-core/src/main/resources/plugin.yml
@@ -10,6 +10,7 @@ softdepend: [WorldGuard, GriefPrevention]
 commands:
   honeypot:
     description: Creates or deletes a honeypot block
+    aliases: [hp]
 
 permissions:
   honeypot.gui:
@@ -45,6 +46,9 @@ permissions:
   honeypot.upgrade:
     description: Upgrades old Honeypots to new ones
     default: op
+  honeypot.history:
+    description: Allows querying and modifying the history table
+    default: op
   honeypot.*:
     description: Allows all Honeypot permissions
     default: op
@@ -59,3 +63,4 @@ permissions:
       honeypot.locate: true
       honeypot.update: true
       honeypot.upgrade: true
+      honeypot.history: true

--- a/honeypot-core/src/main/resources/plugin.yml
+++ b/honeypot-core/src/main/resources/plugin.yml
@@ -13,28 +13,28 @@ commands:
 
 permissions:
   honeypot.gui:
-    description: Allows a user to use the honeypot gui
+    description: Allows a user to use the Honeypot GUI
     default: op
   honeypot.commands:
-    description: Allows a user to use honeypot commands (necessary for /honeypot create and remove)
+    description: Allows a user to use Honeypot commands (necessary for all commands)
     default: op
   honeypot.create:
-    description: Allows a user to create honeypot blocks
+    description: Allows a user to create Honeypot blocks
     default: op
-  honeypot.remove:
-    description: Allows a user to remove honeypot blocks
+  honeypot.break:
+    description: Allows a user to remove Honeypot blocks
     default: op
-    honeypot.removecommand:
-    description: Allows players to remove honeypots with the command, but not break them if honeypot.remove is set
+    honeypot.remove:
+    description: Allows players to remove Honeypots with the command, but not break them
     default: op
   honeypot.locate:
-    description: Allows a user to see nearby honeypot blocks
+    description: Allows a user to see nearby Honeypot blocks
     default: op
   honeypot.exempt:
     description: Exempts a player from break actions
     default: op
   honeypot.notify:
-    description: Allows user to be notified of honeypot breaks
+    description: Allows user to be notified of Honeypot breaks
     default: op
   honeypot.reload:
     description: Allows user to reload the config
@@ -46,13 +46,13 @@ permissions:
     description: Upgrades old Honeypots to new ones
     default: op
   honeypot.*:
-    description: Allows all honeypot permissions
+    description: Allows all Honeypot permissions
     default: op
     children:
       honeypot.commands: true
       honeypot.create: true
+      honeypot.break: true
       honeypot.remove: true
-      honeypot.removecommand: true
       honeypot.exempt: true
       honeypot.notify: true
       honeypot.reload: true

--- a/honeypot-core/src/test/java/org/reprogle/honeypot/commands/TestHelpCommand.java
+++ b/honeypot-core/src/test/java/org/reprogle/honeypot/commands/TestHelpCommand.java
@@ -40,7 +40,8 @@ public class TestHelpCommand {
 			"  " + ChatColor.WHITE + "/honeypot " + ChatColor.GRAY + "remove (all | near) (optional)\n" +
 			"  " + ChatColor.WHITE + "/honeypot " + ChatColor.GRAY + "reload\n" +
 			"  " + ChatColor.WHITE + "/honeypot " + ChatColor.GRAY + "locate\n" + 
-			"  " + ChatColor.WHITE + "/honeypot " + ChatColor.GRAY + "gui\n \n" + 
+			"  " + ChatColor.WHITE + "/honeypot " + ChatColor.GRAY + "gui\n" +
+			"  " + ChatColor.WHITE + "/honeypot " + ChatColor.GRAY + "history [query | delete | purge] \n \n" + 
 			ChatColor.WHITE + "-----------------------";
 
 		// Check to make sure players without permissions don't have access

--- a/honeypot-core/src/test/java/org/reprogle/honeypot/config/TestConfigAccess.java
+++ b/honeypot-core/src/test/java/org/reprogle/honeypot/config/TestConfigAccess.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.reprogle.honeypot.Honeypot;
-import org.reprogle.honeypot.HoneypotConfigManager;
+import org.reprogle.honeypot.utils.HoneypotConfigManager;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;

--- a/honeypot-core/src/test/java/org/reprogle/honeypot/events/TestBlockFromToEvent.java
+++ b/honeypot-core/src/test/java/org/reprogle/honeypot/events/TestBlockFromToEvent.java
@@ -41,7 +41,7 @@ public class TestBlockFromToEvent {
 
 		BlockMock torch = world.createBlock(new Coordinate(0, 65, 0));
 		torch.setType(Material.TORCH);
-		Honeypot.getHBM().createBlock(torch, "nothing");
+		Honeypot.getBlockManager().createBlock(torch, "nothing");
 
 		BlockMock water = world.createBlock(new Coordinate(0, 65, 1));
 		water.setType(Material.WATER);
@@ -49,7 +49,7 @@ public class TestBlockFromToEvent {
 		server.getPluginManager().callEvent(new BlockFromToEvent(water, torch));
 		server.getScheduler().performTicks(20L);
 
-		Assertions.assertTrue(Honeypot.getHBM().isHoneypotBlock(torch));
+		Assertions.assertTrue(Honeypot.getBlockManager().isHoneypotBlock(torch));
 
 	}
 	

--- a/honeypot-core/src/test/java/org/reprogle/honeypot/storagemanager/TestDatabaseCreation.java
+++ b/honeypot-core/src/test/java/org/reprogle/honeypot/storagemanager/TestDatabaseCreation.java
@@ -59,9 +59,9 @@ public class TestDatabaseCreation {
 		WorldMock worldMock = server.addSimpleWorld("world");
 		BlockMock block = worldMock.createBlock(new Coordinate(0, 65, 9));	
 		block.setType(Material.DIAMOND_ORE);
-		Honeypot.getHBM().createBlock(block, "kick");
+		Honeypot.getBlockManager().createBlock(block, "kick");
 
-		List<HoneypotBlockObject> blocks = Honeypot.getHBM().getAllHoneypots();
+		List<HoneypotBlockObject> blocks = Honeypot.getBlockManager().getAllHoneypots();
 
 		Assertions.assertEquals("kick", blocks.get(0).getAction());
 		Assertions.assertEquals("0, 65, 9", blocks.get(0).getCoordinates());

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.reprogle</groupId>
     <artifactId>honeypot-parent</artifactId>
-    <version>2.3.1</version>
+    <version>2.4.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.reprogle</groupId>
     <artifactId>honeypot-parent</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
Created a new /honeypot history command for querying player history. Permission is honeypot.history. 
Added history GUI button to main menu. 
Added alias to the honeypot command, /hp. 
Updated some configs and language files. 
Added info command and warning messages if server admins try to load Honeypot on a version of Spigot this plugin doesn't yet support. 
Fixed a bug where players who lit TNT to break blocks wouldn't activate Honeypot blocks. 
Added more caching checks so Honeypots can also get data from the cache, not just verify their status. 
Added methods to retrieve the HoneypotBlockObject from just a block. 
Fixed improper permission registration in plugin.yml caused by a recent change to the remove and break permissions.
